### PR TITLE
Fixed Offset Issues - positive/negative & hours/minutes

### DIFF
--- a/world_time_app/lib/services/world_time.dart
+++ b/world_time_app/lib/services/world_time.dart
@@ -21,11 +21,24 @@ class WorldTime {
 
       // get properties from json
       String datetime = data['datetime'];
-      String offset = data['utc_offset'].substring(0,3);
-
-      // create DateTime object
+      
+      //decoding offset sign, hours and minutes
+      String offset_sign = data['utc_offset'].substring(0,1);
+      String offset_hours = data['utc_offset'].substring(1,3);
+      String offset_minutes = data['utc_offset'].substring(4,);
+      
+      //parsing DateTime
       DateTime now = DateTime.parse(datetime);
-      now = now.add(Duration(hours: int.parse(offset)));
+      
+      //adding or subtracting hours and minutes offset depending on  +/- sign of offset respectively
+    if(offset_sign=='+')
+      {
+        now = now.add(Duration(hours: int.parse(offset_hours),minutes: int.parse(offset_minutes)));
+      }
+    else if(offset_sign=="-")
+      {
+        now = now.subtract(Duration(hours: int.parse(offset_hours),minutes: int.parse(offset_minutes)));
+      }
 
       // set the time property
       isDaytime = now.hour > 6 && now.hour < 20 ? true : false;


### PR DESCRIPTION
@iamshaunjp @pulkit2001
Fixes ISSUE #29

**ISSUE WITH EARLIER CODE**
The earlier code only had a provision for timezones with positive offsets and with 0 minutes offset (offset was a positive integral multiple of one hour). It would report the wrong time for zones with negative offsets by adding instead of subtracting them and also misreport time for zones whose minutes offset isn't zero (India for example)

**COMMIT TO FIX**
This commit creates the capability to read the sign of the offset and adds or subtracts the offset from UTC time accordingly. Also, it reads the offset in minutes and adds that along with hours to the UCT time to show the correct time for zones like India which have an offset of 5 hours 30 minutes

**TEST**
This commit has been tested for various time zones to ensure it doesn't fail in any and all tests have been successful.

**THANK YOU**