### PR TITLE
Update quote_card.dart

### DIFF
--- a/quotes/lib/quote_card.dart
+++ b/quotes/lib/quote_card.dart
@@ -4,8 +4,8 @@ import 'quote.dart';
 class QuoteCard extends StatelessWidget {
 
   final Quote quote;
-  final Function delete;
-  QuoteCard({ this.quote, this.delete });
+  final Function() delete;
+  QuoteCard({ required this.quote, required this.delete });
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This will resolve the errors, like "The parameter 'delete' can't have a value of 'null' because of its type, but the implicit default value is 'null'. Try adding either an explicit non-'null' default value or the 'required' modifier"