### PR TITLE
Update loading.dart

### DIFF
--- a/world_time_app/lib/pages/loading.dart
+++ b/world_time_app/lib/pages/loading.dart
@@ -11,7 +11,7 @@ class _LoadingState extends State<Loading> {
 
   void getData() async {
 
-    Response response = await get('https://jsonplaceholder.typicode.com/todos/1');
+    Response response = await get(Uri.http('jsonplaceholder.typicode.com', '/todos/1' ));
     // print(response.body);
     Map data = jsonDecode(response.body);
     print(data);


### PR DESCRIPTION
Getting an error on the URL inside the get() method that states "The argument type 'String' can't be assigned to the parameter type 'Uri'"

The .http() method creates a new http uri from authority, path and query.
Read more on it on the official Dart wiki:
https://api.dart.dev/stable/2.10.5/dart-core/Uri/Uri.http.html
